### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Description
+A clear description of what this PR does and why.
+
+## Related Issue
+Closes #<issue_number>
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Refactor
+
+## Changes Made
+- 
+- 
+- 
+
+## Testing
+Describe how you tested your changes:
+- [ ] Tested locally
+- [ ] Added/updated tests
+
+## Checklist
+- [ ] Code follows existing style
+- [ ] No breaking changes
+- [ ] README updated if needed
+- [ ] No console errors or warnings


### PR DESCRIPTION
Closes #2

Added a pull request template under `.github/PULL_REQUEST_TEMPLATE.md` to standardize contributions with description, related issue, type of change, testing and checklist sections.